### PR TITLE
fix: cache key file safe characters

### DIFF
--- a/triage/lib/triage.ts
+++ b/triage/lib/triage.ts
@@ -72,7 +72,9 @@ export const cache = {
       toHash,
     ].join("_");
 
-    return cacheKey;
+    // The cache key must be a valid file name so here we replace potentially invalid characters
+    // with underscores 
+    return cacheKey.replace(/[^a-zA-Z0-9_]/g, "_");
   },
 
   async has(key: string) {


### PR DESCRIPTION
When triaging commits over from `next` to `release/minor/v7.5.0` I was getting an error when the cache was being written to disk. The cause was that the cache key contained path separators and ultimately we were trying to write to a subdirectory that didn't exist.

Here I simply replace any characters that might not be safe in a filename with an underscore. Assuming consistent use of the `getKey` function and that no one attempt to build the key themselves without this change then this should be totally fine.  