### PR TITLE
milestones: Rename to MilestonePullRequest to make it distinct from PR type

### DIFF
--- a/lib/milestones.ts
+++ b/lib/milestones.ts
@@ -257,7 +257,7 @@ const getPrsInMilestoneQuery = `\
   }
 `;
 
-interface PullRequest {
+interface MilestonePullRequest {
   title: string;
   number: number;
   url: string;
@@ -271,7 +271,9 @@ interface PullRequest {
 
 export async function getPrsInMilestone(milestoneNumber: number) {
   const res = await gqlGitHub<{
-    repository: { milestone: { pullRequests: { nodes: Array<PullRequest> } } };
+    repository: {
+      milestone: { pullRequests: { nodes: Array<MilestonePullRequest> } };
+    };
   }>({
     query: getPrsInMilestoneQuery,
     variables: { milestoneNumber },


### PR DESCRIPTION
There was already a `PR` type. I figured it was unnecessarily confusing to also have a `PullRequest` type.
Really wish for GQL typegen or some other way to get strongly typed gql here 🙂 